### PR TITLE
Fix for arrow-glib 3.0.0

### DIFF
--- a/ext/arrow-nmatrix/arrow-nmatrix.c
+++ b/ext/arrow-nmatrix/arrow-nmatrix.c
@@ -61,17 +61,28 @@ garrow_type_to_nmatrix_dtype(GArrowType arrow_type)
   case GARROW_TYPE_HALF_FLOAT:
   case GARROW_TYPE_STRING:
   case GARROW_TYPE_BINARY:
+  case GARROW_TYPE_FIXED_SIZE_BINARY:
   case GARROW_TYPE_DATE32:
   case GARROW_TYPE_DATE64:
   case GARROW_TYPE_TIMESTAMP:
   case GARROW_TYPE_TIME32:
   case GARROW_TYPE_TIME64:
-  case GARROW_TYPE_INTERVAL:
-  case GARROW_TYPE_DECIMAL:
+  case GARROW_TYPE_INTERVAL_MONTHS:
+  case GARROW_TYPE_INTERVAL_DAY_TIME:
+  case GARROW_TYPE_DECIMAL128:
+  case GARROW_TYPE_DECIMAL256:
   case GARROW_TYPE_LIST:
   case GARROW_TYPE_STRUCT:
-  case GARROW_TYPE_UNION:
+  case GARROW_TYPE_SPARSE_UNION:
+  case GARROW_TYPE_DENSE_UNION:
   case GARROW_TYPE_DICTIONARY:
+  case GARROW_TYPE_MAP:
+  case GARROW_TYPE_EXTENSION:
+  case GARROW_TYPE_FIXED_SIZE_LIST:
+  case GARROW_TYPE_DURATION:
+  case GARROW_TYPE_LARGE_STRING:
+  case GARROW_TYPE_LARGE_BINARY:
+  case GARROW_TYPE_LARGE_LIST:
   default:
     break;
   }
@@ -132,25 +143,25 @@ nmatrix_dtype_to_garrow_data_type(nm_dtype_t nmatrix_type)
 
   switch (nmatrix_type) {
   case BYTE:
-    arrow_data_type = garrow_uint8_data_type_new();
+    arrow_data_type = GARROW_DATA_TYPE(garrow_uint8_data_type_new());
     break;
   case INT8:
-    arrow_data_type = garrow_int8_data_type_new();
+    arrow_data_type = GARROW_DATA_TYPE(garrow_int8_data_type_new());
     break;
   case INT16:
-    arrow_data_type = garrow_int16_data_type_new();
+    arrow_data_type = GARROW_DATA_TYPE(garrow_int16_data_type_new());
     break;
   case INT32:
-    arrow_data_type = garrow_int32_data_type_new();
+    arrow_data_type = GARROW_DATA_TYPE(garrow_int32_data_type_new());
     break;
   case INT64:
-    arrow_data_type = garrow_int64_data_type_new();
+    arrow_data_type = GARROW_DATA_TYPE(garrow_int64_data_type_new());
     break;
   case FLOAT32:
-    arrow_data_type = garrow_float_data_type_new();
+    arrow_data_type = GARROW_DATA_TYPE(garrow_float_data_type_new());
     break;
   case FLOAT64:
-    arrow_data_type = garrow_double_data_type_new();
+    arrow_data_type = GARROW_DATA_TYPE(garrow_double_data_type_new());
     break;
   case COMPLEX64:
   case COMPLEX128:

--- a/ext/arrow-nmatrix/extconf.rb
+++ b/ext/arrow-nmatrix/extconf.rb
@@ -14,7 +14,7 @@
 
 require "mkmf-gnome2"
 
-required_pkg_config_package("arrow-glib")
+required_pkg_config_package(["arrow-glib", 3])
 
 [
   ["glib2", "ext/glib2"],


### PR DESCRIPTION
This change fixes compile errors due to arrow-glib-3.0.

The following warnings related to arrow-glib are remaining:

```
compiling ../../../../ext/arrow-nmatrix/arrow-nmatrix.c
In file included from /opt/arrow-dbg/include/arrow-glib/arrow-glib.h:23,
                 from ../../../../ext/arrow-nmatrix/arrow-nmatrix.c:17:
/opt/arrow-dbg/include/arrow-glib/version.h:297:36: warning: "GARROW_VERSION_0_16" is not defined, evaluates to 0 [-Wundef]
  297 | #if GARROW_VERSION_MIN_REQUIRED >= GARROW_VERSION_0_16
      |                                    ^~~~~~~~~~~~~~~~~~~
/opt/arrow-dbg/include/arrow-glib/version.h:305:34: warning: "GARROW_VERSION_0_16" is not defined, evaluates to 0 [-Wundef]
  305 | #if GARROW_VERSION_MAX_ALLOWED < GARROW_VERSION_0_16
      |                                  ^~~~~~~~~~~~~~~~~~~
```